### PR TITLE
Add numpy to pyproject.toml as dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     'ipython',
     'matplotlib',
     'pyevtk',
+    'numpy'
 ]
 
 [project.scripts]


### PR DESCRIPTION
I think we should add numpy as regular dependency (and keep cuPy as optional). technically, numpy isn't needed if CUDA is used, but I think it's good practice if this works on CPU as a baseline (and then the cuPy is optional, on top).